### PR TITLE
CLOUD-1935: Minor fix in outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -25,5 +25,5 @@ output "app_aws_secrets_arn" {
 
 output "app_aws_secrets_name" {
   description = "The Amazon Secret Manager name of the Azure app's secrets."
-  value       = local.create_secret > 0 ? "azure-app-${var.name}" : null
+  value       = local.create_secret > 0 ? "azure-app-${local.kebab_name}" : null
 }


### PR DESCRIPTION
# Description

<!-- markdownlint-disable-next-line MD013 -->
Fix for a small bug in the output of aws secret name.

Fixes [#0](https://usxtech.atlassian.net/browse/CLOUD-0)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
<!-- markdownlint-disable-next-line MD013 -->
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested this locally. Provide the required AWS and Azure credentials either in main.tf or as environment variables.
Do a terraform init ==> terraform plan ==> terraform apply

- [ ] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added documentation to test