### PR TITLE
CLOUD-1935: Change to secret expiry

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -186,6 +186,7 @@ resource "azuread_application_pre_authorized" "known_client_apps" { # for adding
 
 resource "azuread_application_password" "main_app" {
   application_object_id = azuread_application.main_app.object_id
+  end_date_relative     = "867834h"
 }
 
 resource "azuread_service_principal" "main_app" {


### PR DESCRIPTION
# Description

Small change in the module so that the secret created will not expire for 99 years

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested this locally. Provide the required AWS and Azure credentials either in main.tf or as environment variables.
Do a terraform init ==> terraform plan ==> terraform apply

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added documentation to test